### PR TITLE
Fix bug where hard_pulse returns single datatype, would propagate to analytical magnetization values

### DIFF
--- a/Common/pulse/hard_pulse.m
+++ b/Common/pulse/hard_pulse.m
@@ -19,6 +19,6 @@ function pulse = hard_pulse(t,Trf,~)
 %   See also GETPULSE, VIEWPULSE.
 %
 
-pulse = single(~(t < 0 | t>Trf));
+pulse = double(~(t < 0 | t>Trf));
 
 end

--- a/Test/Common/pulse/hard_pulse_Test.m
+++ b/Test/Common/pulse/hard_pulse_Test.m
@@ -1,0 +1,24 @@
+classdef (TestTags = {'Unit', 'SPGR', 'qMT'}) hard_pulse_Test < matlab.unittest.TestCase
+
+    properties
+    end
+    
+    methods (TestClassSetup)
+    end
+    
+    methods (TestClassTeardown)
+    end
+    
+    methods (Test)
+        function test_pulse_returns_single_datatype(testCase)
+            timeRange = -10:0.01:10;
+            Trf = 3;
+            PulseOpt = [];
+            
+            pulse = hard_pulse(timeRange, Trf, PulseOpt);
+            
+            testCase.assertInstanceOf(pulse, 'double')
+        end     
+    end
+    
+end

--- a/Test/Common/sim/BlochSol_Test.m
+++ b/Test/Common/sim/BlochSol_Test.m
@@ -71,7 +71,7 @@ classdef (TestTags = {'Unit', 'SPGR', 'qMT'}) BlochSol_Test < matlab.unittest.Te
             end
             
             %                    Actual ,  Expected
-            testCase.assertEqual(double(M(end,:)), M0', 'AbsTol', 0.001);
+            testCase.assertEqual(M(end,:), M0', 'AbsTol', 0.001);
         end
         
         function test_no_longi_mag_evol_for_transverse_inital_mag_inf_t2_t1(testCase)
@@ -105,7 +105,7 @@ classdef (TestTags = {'Unit', 'SPGR', 'qMT'}) BlochSol_Test < matlab.unittest.Te
             end
             
             %                    Actual                     , Expected
-            testCase.assertEqual(double([M(end,3) M(end,4)]), [M0(3) M0(4)], 'AbsTol', 0.001);
+            testCase.assertEqual([M(end,3) M(end,4)], [M0(3) M0(4)], 'AbsTol', 0.001);
         end
         
         function test_magn_evols_to_equilibrium_vals(testCase)
@@ -132,7 +132,7 @@ classdef (TestTags = {'Unit', 'SPGR', 'qMT'}) BlochSol_Test < matlab.unittest.Te
             end
             
             %                    Actual ,  Expected
-            testCase.assertEqual(double(M(end,:)), [0 0 Param.M0f Param.M0r], 'AbsTol', 0.001);
+            testCase.assertEqual(M(end,:), [0 0 Param.M0f Param.M0r], 'AbsTol', 0.001);
         end
         
         function test_mag_goes_to_zero_for_time_much_greater_than_t2f(testCase)
@@ -159,7 +159,7 @@ classdef (TestTags = {'Unit', 'SPGR', 'qMT'}) BlochSol_Test < matlab.unittest.Te
             end
             
             %                    Actual ,  Expected
-            testCase.assertEqual(double(M(end,1:2)), [0 0], 'AbsTol', 0.001);
+            testCase.assertEqual(M(end,1:2), [0 0], 'AbsTol', 0.001);
         end
         
         function test_steady_state_smaller_for_small_delta_than_big(testCase)


### PR DESCRIPTION
Fixed a bug where hard_pulse.m returned data of type single instead of double, which would propagate to magnetization values calculated using BlochSol.m (analytical equations).

- Changed hard_pulse.m implementation to return double
- Added a unit test for hard_pulse that will catch this issue in the future if ever hard_pulse is reverted to an older commit.
- Modified the BlochSol tests that required conversion of magnetization to double due to the bug.