### PR TITLE
Minor fixes resulting from new_doc review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ External/Faddeeva_MATLAB/Faddeeva.o
 docs/.idea
 *.pyc
 Data
+
+# Temporary folder
+tmp/

--- a/Models/T1_relaxometry/vfa_t1.m
+++ b/Models/T1_relaxometry/vfa_t1.m
@@ -55,9 +55,9 @@ end
         voxelwise = 1;
         
         % Protocol
-        Prot  = struct('VFAData',struct('Format',{{'FlipAngle' 'TR'}},...
+        Prot  = struct('VFAData',struct('Format',{{'Flip Angle (deg)' 'TR (s)'}},...
                                          'Mat', [3 0.015; 20 0.015])); % You can define a default protocol here.
-        
+
         % fitting options
         st           = [2000 0.7]; % starting point
         lb           = [0   0.00001]; % lower bound

--- a/qMRLab.m
+++ b/qMRLab.m
@@ -658,7 +658,7 @@ else
 
     figure(68)
 
-    set(68,'Name',['Fitting results of voxel [' num2str([x y z]) ']'],'NumberTitle','off');
+    set(68,'Name',['Fitting results of voxel [' num2str([info_dcm.Position(1) info_dcm.Position(2) z]) ']'],'NumberTitle','off');
     haxes = get(68,'children'); haxes = haxes(strcmp(get(haxes,'Type'),'axes'));
     
     if ~isempty(haxes)

--- a/qMRLab.m
+++ b/qMRLab.m
@@ -587,7 +587,8 @@ RefreshPlot(handles);
 
 % SAVE FIG
 function SaveFig_Callback(hObject, eventdata, handles)
-[FileName,PathName] = uiputfile(fullfile('FitResults','NewFig.fig'));
+[FileName,PathName] = uiputfile(fullfile('.','NewFig.fig'));
+
 if PathName == 0, return; end
 xl = xlim;
 yl = ylim;

--- a/qMRLab.m
+++ b/qMRLab.m
@@ -653,7 +653,11 @@ else
     
     Sim.Opt.AddNoise = 0;
     % Create axe
+    if ishandle(68), clf(68), end % If a data fit check has already been run,
+                                  % clear the previous data from the figure plot
+
     figure(68)
+
     set(68,'Name',['Fitting results of voxel [' num2str([x y z]) ']'],'NumberTitle','off');
     haxes = get(68,'children'); haxes = haxes(strcmp(get(haxes,'Type'),'axes'));
     

--- a/qMRLab.m
+++ b/qMRLab.m
@@ -601,13 +601,16 @@ delete(h);
 % HISTOGRAM FIG
 function Histogram_Callback(hObject, eventdata, handles)
 Data =  getappdata(0,'Data');
+Model = class(GetAppData('Model')); % Get cur model name (string)
 Map = getimage(handles.FitDataAxe);
+
 % exclude the 0 from mask
-if isfield(Data,'Mask')    
-    if ~isempty(Data.Mask)
-        Map(~rot90(Data.Mask)) = 0;
+if isfield(Data.(Model),'Mask')
+    if ~isempty(Data.(Model).Mask)
+        Map(~rot90(Data.(Model).Mask)) = 0;
     end
 end
+
 SourceFields = cellstr(get(handles.SourcePop,'String'));
 Source = SourceFields{get(handles.SourcePop,'Value')};
 ii = find(Map);


### PR DESCRIPTION
Here's a few fixes for bugs that I discovered while testing @ileppe 's new_doc branch. I'm requesting to merge back into that branch, since that's the branch that I was using when I discovered them. 

@agahkarakuzu I set you as the reviewer.

1. bee6ada – Added an ignore rule for a tmp/ folder (which doesn't exist by default). It's existence doesn't clutter the project directory, and should be useful for dev ppl running tests (who can create the tmp/ folder if needed, without accidentally pushing those tmp working folders in a commit).

---

2. a80ba8b – Added the units to the VFA protocol in the GUI protocol tab. This should be done for all method; new users cannot be expected to know the units otherwise.

![fig1](https://user-images.githubusercontent.com/1421029/34625558-bad1ddd6-f233-11e7-8f91-766d32bf249a.png)

---

3. 54d6f90 – Fixed a bug where the mask was not taken into account for the histogram button. See example below (before & after) for a B1 map where all values outside the brain are equal to 1 (e.g. in default VFA data).

![fig2](https://user-images.githubusercontent.com/1421029/34625606-f0bcab1a-f233-11e7-8278-38074b7f565d.png)

---

4. 4b3d9ee – Fixed a bug where if "View data fits" was run multiple times without closing the window, the data from previous voxels were not cleared from the bottom plot. 

![fig3](https://user-images.githubusercontent.com/1421029/34625653-20a2db06-f234-11e7-83de-2ff2621d85b8.png)

---

5. a5ff666 – Fixed bug where the cursor [x, y] value did not match the [x, y] value plotted as the figure title produced by "View data fit".

![fig4](https://user-images.githubusercontent.com/1421029/34625690-499d7cfa-f234-11e7-82fc-324fed5f2f62.png)

---

6. 376970a – Fixed bug which would throw an error if the user tried to save one of the loaded data images (e.g. B1map) before a Fit event was executed (due to the lack of FitResults folder). 