### PR TITLE
 Improvements to displayed data cursor information

### DIFF
--- a/qMRLab.m
+++ b/qMRLab.m
@@ -874,9 +874,9 @@ fig = gcf;
 handles.dcm_obj = datacursormode(fig);
 guidata(gcbf,handles);
 
-set(handles.dcm_obj,'UpdateFcn',{@myupdatefcn,handles})
+set(handles.dcm_obj,'UpdateFcn',{@dataCursorUpdateFcn,handles})
 
-function txt = myupdatefcn(empt,event_obj,handles)
+function txt = dataCursorUpdateFcn(h_PointDataTip,event_obj,handles)
 % Customizes text of data tips
 
 pos = get(event_obj,'Position');

--- a/qMRLab.m
+++ b/qMRLab.m
@@ -874,6 +874,24 @@ fig = gcf;
 handles.dcm_obj = datacursormode(fig);
 guidata(gcbf,handles);
 
+set(handles.dcm_obj,'UpdateFcn',{@myupdatefcn,handles})
+
+function txt = myupdatefcn(empt,event_obj,handles)
+% Customizes text of data tips
+
+pos = get(event_obj,'Position');
+data = event_obj.Target.CData;
+
+SourceFields = cellstr(get(handles.SourcePop,'String'));
+Source = SourceFields{get(handles.SourcePop,'Value')};
+
+sliceNum = str2double(get(handles.SliceValue,'String'));
+
+txt = {['Source: ', Source],...
+       ['[X,Y]: ', '[', num2str(pos(1)), ',', num2str(pos(2)), ']'],...
+       ['Slice: ', num2str(sliceNum)],...
+	   ['Value: ', num2str(data(pos(2), pos(1)))]};
+
 function RefreshPlot(handles)
 if isempty(handles.CurrentData), return; end
 Current = GetCurrent(handles);


### PR DESCRIPTION
Resolves issue #88 opened by @jcohenadad .

New features:

* RGB component displayed by the interactive data cursor has been removed.
* Improved name of information displayed by data cursor (e.g. Index -> Value).
* Added additional information displayed by data cursor (Data source, slice number).

See screenshot below:

![datacursor](https://user-images.githubusercontent.com/1421029/35303549-e814a4c6-006c-11e8-8dd9-73902e18e66d.png)

If anyone feels that the source and slice number might be redundant since they are also displayed on the left panel, I have no issue with removing them. However, the source (data-type) is often cut-off in that panel (see screenshot), and the slice number could be useful if users take a screenshot for their own notes and/or share with others.