### PR TITLE
Bug fix: Remove double parentheses from mask input names in documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,17 +25,19 @@ before_install:
     - travis_retry sudo apt-get install -y -qq software-properties-common python-software-properties
     - travis_retry sudo apt-add-repository -y ppa:octave/stable
     - travis_retry sudo apt-get -y -qq update
-    #- travis_retry sudo apt-get install -y wget
+    - travis_retry sudo apt-get install -y wget
     # get Octave 4,0
     - travis_retry sudo apt-get -y -qq install octave liboctave-dev octave-pkg-dev
     # Please comment in following section if you need to update packages or add a new one
     # If following section is going to be commented in, please set cacheState to false in startup.m
     # --------------
-    #- travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/struct-1.0.14.tar.gz -P /home/travis/octave
-    #- travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/optim-1.5.2.tar.gz -P /home/travis/octave
-    #- travis_retry wget https://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/io-2.4.10.tar.gz -P /home/travis/octave
-    #- travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/statistics-1.3.0.tar.gz -P /home/travis/octave
-    #- travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/image-2.6.1.tar.gz -P /home/travis/octave
+    #- travis_retry wget -O /home/travis/octave/OctavePackages.zip https://osf.io/t465n/download
+    #- unzip /home/travis/octave/OctavePackages.zip
+    - travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/struct-1.0.14.tar.gz -P /home/travis/octave
+    - travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/optim-1.5.2.tar.gz -P /home/travis/octave
+    - travis_retry wget https://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/io-2.4.10.tar.gz -P /home/travis/octave
+    - travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/statistics-1.3.0.tar.gz -P /home/travis/octave
+    - travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/image-2.6.1.tar.gz -P /home/travis/octave
     # --------------
 
 

--- a/Models/Magnetization_transfer/qmt_bssfp.m
+++ b/Models/Magnetization_transfer/qmt_bssfp.m
@@ -6,7 +6,7 @@ classdef qmt_bssfp < AbstractModel
 % Inputs:
 %   MTdata        4D Magnetization Transfer data
 %   (R1map)       1/T1map (optional)
-%   ((Mask))      Binary mask to accelerate the fitting (optional)
+%   (Mask)        Binary mask to accelerate the fitting (optional)
 %
 % Outputs:
 %     F         Ratio of number of restricted pool to free pool, defined 

--- a/Models/Magnetization_transfer/qmt_sirfse.m
+++ b/Models/Magnetization_transfer/qmt_sirfse.m
@@ -11,7 +11,7 @@ classdef qmt_sirfse < AbstractModel
 % Inputs:
 %   MTdata              Magnetization Transfert data
 %   (R1map)             1/T1map (OPTIONAL but recommended)
-%   ((Mask))            Binary mask to accelerate the fitting (OPTIONAL)
+%   (Mask)              Binary mask to accelerate the fitting (OPTIONAL)
 %
 % Outputs:
 %   F                   Ratio of number of restricted pool to free pool, defined 

--- a/Models/Magnetization_transfer/qmt_spgr.m
+++ b/Models/Magnetization_transfer/qmt_spgr.m
@@ -11,7 +11,7 @@ classdef qmt_spgr < AbstractModel
 %   (R1map)             1/T1map (VFA RECOMMENDED Boudreau 2017 MRM)
 %   (B1map)             B1 field map, used for flip angle correction (=1 if not provided)
 %   (B0map)             B0 field map, used for offset correction (=0Hz if not provided)
-%   ((Mask))            Binary mask to accelerate the fitting
+%   (Mask)              Binary mask to accelerate the fitting
 %
 % Outputs:
 %   F                   Ratio of number of restricted pool to free pool, defined

--- a/bootstrapTest.m
+++ b/bootstrapTest.m
@@ -8,7 +8,7 @@ addpath(genpath(pwd));
 %  <false> if cache (for octave packages) is cleared
 %  <true> if the same cache (for octave packages) is still in use
 
-cacheState = true;
+cacheState = false;
 % -----------------------------------------------------
 
 if moxunit_util_platform_is_octave


### PR DESCRIPTION
Resolves issue #201 

(not 200, like the branch name was mistakenly was identified as).