### PR TITLE
Hotfix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,13 +31,13 @@ before_install:
     # Please comment in following section if you need to update packages or add a new one
     # If following section is going to be commented in, please set cacheState to false in startup.m
     # --------------
-    - travis_retry wget -O /home/travis/octave/OctavePackages.zip https://osf.io/t465n/download
-    - unzip /home/travis/octave/OctavePackages.zip
-    #- travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/struct-1.0.14.tar.gz -P /home/travis/octave
-    #- travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/optim-1.5.2.tar.gz -P /home/travis/octave
-    #- travis_retry wget https://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/io-2.4.10.tar.gz -P /home/travis/octave
-    #- travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/statistics-1.3.0.tar.gz -P /home/travis/octave
-    #- travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/image-2.6.1.tar.gz -P /home/travis/octave
+    #- travis_retry wget -O /home/travis/octave/OctavePackages.zip https://osf.io/t465n/download
+    #- unzip /home/travis/octave/OctavePackages.zip
+    - travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/struct-1.0.14.tar.gz -P /home/travis/octave
+    - travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/optim-1.5.2.tar.gz -P /home/travis/octave
+    - travis_retry wget https://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/io-2.4.10.tar.gz -P /home/travis/octave
+    - travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/statistics-1.3.0.tar.gz -P /home/travis/octave
+    - travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/image-2.6.1.tar.gz -P /home/travis/octave
     # --------------
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
     # Please comment in following section if you need to update packages or add a new one
     # If following section is going to be commented in, please set cacheState to false in startup.m
     # --------------
-    - travis_retry wget -O OctavePackages.zip https://osf.io/t465n/download -P /home/travis/octave
+    - travis_retry wget -O /home/travis/octave/OctavePackages.zip https://osf.io/t465n/download
     - unzip /home/travis/octave/OctavePackages.zip
     #- travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/struct-1.0.14.tar.gz -P /home/travis/octave
     #- travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/optim-1.5.2.tar.gz -P /home/travis/octave

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
     # Please comment in following section if you need to update packages or add a new one
     # If following section is going to be commented in, please set cacheState to false in startup.m
     # --------------
-    - tavis_retry wget -O OctavePackages.zip https://osf.io/t465n/download -P /home/travis/octave
+    - travis_retry wget -O OctavePackages.zip https://osf.io/t465n/download -P /home/travis/octave
     - unzip /home/travis/octave/OctavePackages.zip
     #- travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/struct-1.0.14.tar.gz -P /home/travis/octave
     #- travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/optim-1.5.2.tar.gz -P /home/travis/octave

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,14 @@ before_install:
     - travis_retry sudo apt-get install -y -qq software-properties-common python-software-properties
     - travis_retry sudo apt-add-repository -y ppa:octave/stable
     - travis_retry sudo apt-get -y -qq update
-    #- travis_retry sudo apt-get install -y wget
+    - travis_retry sudo apt-get install -y wget
     # get Octave 4,0
     - travis_retry sudo apt-get -y -qq install octave liboctave-dev octave-pkg-dev
     # Please comment in following section if you need to update packages or add a new one
     # If following section is going to be commented in, please set cacheState to false in startup.m
     # --------------
+    - tavis_retry wget -O OctavePackages.zip https://osf.io/t465n/download -P /home/travis/octave
+    - unzip /home/travis/octave/OctavePackages.zip
     #- travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/struct-1.0.14.tar.gz -P /home/travis/octave
     #- travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/optim-1.5.2.tar.gz -P /home/travis/octave
     #- travis_retry wget https://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/io-2.4.10.tar.gz -P /home/travis/octave

--- a/bootstrapTest.m
+++ b/bootstrapTest.m
@@ -8,7 +8,7 @@ addpath(genpath(pwd));
 %  <false> if cache (for octave packages) is cleared
 %  <true> if the same cache (for octave packages) is still in use
 
-cacheState = true;
+cacheState = false;
 % -----------------------------------------------------
 
 if moxunit_util_platform_is_octave


### PR DESCRIPTION
@mathieuboudreau I fixed using present convention which is:

i)  Edit travis configuration file to command in related lines
ii)  Set `cacheState` to false in `bootstrapTest.m`

We should keep these changes till cache walks to the PR and master. Then we can revert these changes to use cache to reduce build time. 

There are two solutions to avoid doing this in the future, as Travis cache is not persistent: 

1) If we can generate compiled Octave package files for Trusty 64, we can update them to the OSF and get rid of caching. 
2) Including a cache-check condition to the Travis configuration and arranging the flow according to that. 


