### PR TITLE
[BUG] Fix hardcoded folder links in GUI to take into account new src/ folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # qMRLab (beta)
-[![Build Status](https://travis-ci.org/neuropoly/qMRLab.svg?branch=master)](https://travis-ci.org/neuropoly/qMRLab)[![Coverage Status](https://coveralls.io/repos/github/neuropoly/qMRLab/badge.svg?branch=coverage-clean)](https://coveralls.io/github/neuropoly/qMRLab?branch=coverage-clean)
+[![Build Status](https://travis-ci.org/neuropoly/qMRLab.svg?branch=master)](https://travis-ci.org/neuropoly/qMRLab)[![Coverage Status](https://coveralls.io/repos/github/neuropoly/qMRLab/badge.svg?branch=master)](https://coveralls.io/github/neuropoly/qMRLab?branch=master)
 
 Welcome to qMRLab, all your quantitative MRI needs under one umbrella! 
 

--- a/qMRLab.m
+++ b/qMRLab.m
@@ -214,7 +214,7 @@ end
 SetAppData(Data);
 
 % Now create Simulation panel
-handles.methodfiles = fullfile(handles.root,'Models_Functions',[Method 'fun']);
+handles.methodfiles = fullfile(handles.root,'src','Models_Functions',[Method 'fun']);
 % find the Simulation functions of the selected Method
 Methodfun = methods(Method);
 Simfun = Methodfun(~cellfun(@isempty,strfind(Methodfun,'Sim_')));
@@ -281,7 +281,7 @@ end
 function DefaultMethodBtn_Callback(hObject, eventdata, handles)
 Method = GetMethod(handles);
 setappdata(0, 'Method', Method);
-save(fullfile(handles.root,'Common','Parameters','DefaultMethod.mat'),'Method');
+save(fullfile(handles.root,'src','Common','Parameters','DefaultMethod.mat'),'Method');
 
 function PanelOn(panel, handles)
 eval(sprintf('set(handles.%sPanel, ''Visible'', ''on'')', panel));

--- a/qMRLab.m
+++ b/qMRLab.m
@@ -70,7 +70,7 @@ if ~isfield(handles,'opened') % qMRI already opened?
     set(gcf, 'Position', NewPos);
     
     % Fill Menu with models
-    handles.ModelDir = [qMRLabDir filesep 'Models'];
+    handles.ModelDir = [qMRLabDir filesep 'src/Models'];
     guidata(hObject, handles);
     addModelMenu(hObject, eventdata, handles);
     
@@ -92,7 +92,7 @@ if ~isfield(handles,'opened') % qMRI already opened?
     
     SetAppData(FileBrowserList);
     
-    load(fullfile(handles.root,'Common','Parameters','DefaultMethod.mat'));
+    load(fullfile(handles.root,'src','Common','Parameters','DefaultMethod.mat'));
 else
     Method = class(GetAppData('Model'));
 end


### PR DESCRIPTION
Last PR broke the GUI, which I'll take the blame for since I forgot to test the GUI before doing the PR. Even though I didn't touch the GUI files, some links in qMRLab.m are hard-coded relative to the main repo dir, which I wasn't aware of.

We should create a PR-review guideline that includes testing out some features of the GUI that should always be followed. I'll create an issue  for it, but in the meantime this PR needs to be approved quickly.