### PR TITLE
[NEW] Save unwrapped phase as an fit output of b0_dem; can also view in GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # qMRLab (beta)
-[![Build Status](https://travis-ci.org/neuropoly/qMRLab.svg?branch=master)](https://travis-ci.org/neuropoly/qMRLab)[![Coverage Status](https://coveralls.io/repos/github/neuropoly/qMRLab/badge.svg?branch=master)](https://coveralls.io/github/neuropoly/qMRLab?branch=master)
+[![Build Status](https://travis-ci.org/neuropoly/qMRLab.svg?branch=master)](https://travis-ci.org/neuropoly/qMRLab)[![Coverage Status](https://coveralls.io/repos/github/neuropoly/qMRLab/badge.svg?branch=master)](https://coveralls.io/github/neuropoly/qMRLab?branch=master)[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/neuropoly/qMRLab/bids?filepath=qMRLab/mt_sat_example.ipynb)
 
 Welcome to qMRLab, all your quantitative MRI needs under one umbrella! 
 

--- a/src/Models/FieldMaps/b0_dem.m
+++ b/src/Models/FieldMaps/b0_dem.m
@@ -115,7 +115,8 @@ end
                 FitResult.B0map = (Phase_uw(:,:,:,2) - Phase_uw(:,:,:,1))/(obj.Prot.TimingTable.Mat*2*pi);                 
             end
             
-            
+            % Save unwrapped phase
+            FitResult.Phase_uw = Phase_uw;
         end        
     end
 end


### PR DESCRIPTION
Resolves #199 

Changes:

* Unwrapped phase is included in the saved FitResults
* Unwrapped phase can also be viewed after the fitting in the GUI