### PR TITLE
[NEW] Add ISO 8601 date/time format in FitResults output directory name

### DIFF
--- a/qMRLab.m
+++ b/qMRLab.m
@@ -377,15 +377,16 @@ if(~isempty(FitResults.StudyID))
 else
     filename = 'FitResults.mat';
 end
-outputdir = fullfile(FitResults.WD,'FitResults');
+outputdir = fullfile(FitResults.WD,['FitResults_', datestr(datetime('now','TimeZone','local'),'yyyy-mm-ddTHH-MM-SS')]); % ISO 8601 format adapted for MATLAB compatibility
 if ~exist(outputdir,'dir'), mkdir(outputdir); 
 else
-    iii=1; filenamenew = filename;
-    while exist(fullfile(FitResults.WD,'FitResults',filenamenew),'file')
+    iii=1; outputdirnew = outputdir;
+    while exist(outputdirnew,'dir')
         iii=iii+1;
-        filenamenew = strrep(filename,'.mat',['_' num2str(iii) '.mat']);
+        outputdirnew = [outputdir,'_' num2str(iii)];
     end
-    filename = filenamenew;
+    outputdir = outputdirnew;
+    mkdir(outputdir);
 end
 save(fullfile(outputdir,filename),'-struct','FitResults');
 set(handles.CurrentFitId,'String','FitResults.mat');

--- a/qMRLab.m
+++ b/qMRLab.m
@@ -377,7 +377,7 @@ if(~isempty(FitResults.StudyID))
 else
     filename = 'FitResults.mat';
 end
-outputdir = fullfile(FitResults.WD,['FitResults_', datestr(datetime('now','TimeZone','local'),'yyyy-mm-ddTHH-MM-SS')]); % ISO 8601 format adapted for MATLAB compatibility
+outputdir = fullfile(FitResults.WD,['FitResults_', datestr(datetime('now','TimeZone','local'),'yyyy-mm-dd_HH-MM-SS')]); % ISO 8601 format adapted for MATLAB compatibility
 if ~exist(outputdir,'dir'), mkdir(outputdir); 
 else
     iii=1; outputdirnew = outputdir;


### PR DESCRIPTION
Resolves issue #228 

Output example: FitResults_2018-06-11T15-07-30

If a duplicate folder exists (which is unlikely, but could happen if someone changes timezones or when daylight savings time switches), then the it will add "_2" or whatever n'th folder it is to the end of the folder name.

I couldn't follow ISO 8601 exactly (2018-06-11T15:07:30) because MATLAB complained about the ":" symbol during startup (when adding folders to path). @ileppe do you have any other suggestions on formats of how the time could be displayed in the folder name? Or do you want to omit the time altogether and only save the date? I'm open to other formatting suggestions. Please test it out in the GUI to confirm that these changes work correctly for you.