### PR TITLE
[BUG][OCTAVE] Fix bug caused by a recent added dependecy of optim on the statistics toolbox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,9 @@ before_install:
 #- travis_retry wget -O /home/travis/octave/OctavePackages.zip https://osf.io/t465n/download
 #- unzip /home/travis/octave/OctavePackages.zip
 - travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/struct-1.0.14.tar.gz -P /home/travis/octave
+- travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/statistics-1.3.0.tar.gz -P /home/travis/octave
 - travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/optim-1.5.2.tar.gz -P /home/travis/octave
 - travis_retry wget https://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/io-2.4.10.tar.gz -P /home/travis/octave
-- travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/statistics-1.3.0.tar.gz -P /home/travis/octave
 - travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/image-2.6.1.tar.gz -P /home/travis/octave
 # --------------
 - make -C External/MOcov install

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,9 @@ before_install:
 #- travis_retry wget -O /home/travis/octave/OctavePackages.zip https://osf.io/t465n/download
 #- unzip /home/travis/octave/OctavePackages.zip
 - travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/struct-1.0.14.tar.gz -P /home/travis/octave
-- travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/optim-1.5.3.tar.gz -P /home/travis/octave
+- travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/optim-1.5.2.tar.gz -P /home/travis/octave
 - travis_retry wget https://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/io-2.4.10.tar.gz -P /home/travis/octave
-- travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/statistics-1.4.0.tar.gz -P /home/travis/octave
+- travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/statistics-1.3.0.tar.gz -P /home/travis/octave
 - travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/image-2.6.1.tar.gz -P /home/travis/octave
 # --------------
 - make -C External/MOcov install
@@ -71,4 +71,4 @@ jobs:
   - stage: Test (no coverage)
     script: travis_wait 30 octave --no-gui --eval "bootstrapTest;cd('/home/travis/build/neuropoly/qMRLab/Test/MoxUnitCompatible');res=moxunit_runtests('SimTest_qmt_bssfp.m');exit(~res);"
   - stage: Send combined coveralls.io report
-    script: aws s3 cp s3://qmrlab/$TRAVIS_BUILD_NUMBER/ /home/travis/build/neuropoly/qMRLab/Test/MoxUnitCompatible/ --recursive --include "*.json";octave --no-gui --eval "cd('/home/travis/build/neuropoly/qMRLab/');startup;mocov_combine('/home/travis/build/neuropoly/qMRLab/Test/MoxUnitCompatible/','coverage_combined.json')";aws s3 cp /home/travis/build/neuropoly/qMRLab/Test/MoxUnitCompatible/coverage_combined.json s3://qmrlab/$TRAVIS_BUILD_NUMBER/coverage_combined.json;curl --verbose -F json_file=@/home/travis/build/neuropoly/qMRLab/Test/MoxUnitCompatible/coverage_combined.json https://coveralls.io/api/v1/jobs
+    script: aws s3 cp s3://qmrlab/$TRAVIS_BUILD_NUMBER/ /home/travis/build/neuropoly/qMRLab/Test/MoxUnitCompatible/ --recursive --include "*.json";octave --no-gui --eval "bootstrapTest;cd('/home/travis/build/neuropoly/qMRLab/');startup;mocov_combine('/home/travis/build/neuropoly/qMRLab/Test/MoxUnitCompatible/','coverage_combined.json')";aws s3 cp /home/travis/build/neuropoly/qMRLab/Test/MoxUnitCompatible/coverage_combined.json s3://qmrlab/$TRAVIS_BUILD_NUMBER/coverage_combined.json;curl --verbose -F json_file=@/home/travis/build/neuropoly/qMRLab/Test/MoxUnitCompatible/coverage_combined.json https://coveralls.io/api/v1/jobs

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,9 @@ before_install:
 #- travis_retry wget -O /home/travis/octave/OctavePackages.zip https://osf.io/t465n/download
 #- unzip /home/travis/octave/OctavePackages.zip
 - travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/struct-1.0.14.tar.gz -P /home/travis/octave
-- travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/optim-1.5.2.tar.gz -P /home/travis/octave
+- travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/optim-1.5.3.tar.gz -P /home/travis/octave
 - travis_retry wget https://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/io-2.4.10.tar.gz -P /home/travis/octave
-- travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/statistics-1.3.0.tar.gz -P /home/travis/octave
+- travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/statistics-1.4.0.tar.gz -P /home/travis/octave
 - travis_retry wget http://sourceforge.net/projects/octave/files/Octave%20Forge%20Packages/Individual%20Package%20Releases/image-2.6.1.tar.gz -P /home/travis/octave
 # --------------
 - make -C External/MOcov install

--- a/bootstrapTest.m
+++ b/bootstrapTest.m
@@ -14,8 +14,8 @@ cacheState = false;
 if moxunit_util_platform_is_octave
     if ~cacheState
         more off;
-        installist = {'struct-1.0.14.tar.gz','statistics-1.3.0.tar.gz','optim-1.5.2.tar.gz','io-2.4.10.tar.gz','image-2.6.1.tar.gz'};
-        loadlist = {'struct','statistics','optim','io','image'};
+        installist = {'struct-1.0.14.tar.gz','io-2.4.10.tar.gz','statistics-1.3.0.tar.gz','optim-1.5.2.tar.gz','image-2.6.1.tar.gz'};
+        loadlist = {'struct','io','statistics','optim','image'};
         cd('/home/travis/octave');
         for ii=1:length(installist)
             pkg prefix '/home/travis/octave'

--- a/bootstrapTest.m
+++ b/bootstrapTest.m
@@ -14,8 +14,8 @@ cacheState = false;
 if moxunit_util_platform_is_octave
     if ~cacheState
         more off;
-        installist = {'struct-1.0.14.tar.gz','optim-1.5.2.tar.gz','io-2.4.10.tar.gz','statistics-1.3.0.tar.gz','image-2.6.1.tar.gz'};
-        loadlist = {'struct','optim','io','statistics','image'};
+        installist = {'struct-1.0.14.tar.gz','statistics-1.3.0.tar.gz','optim-1.5.2.tar.gz','io-2.4.10.tar.gz','image-2.6.1.tar.gz'};
+        loadlist = {'struct','statistics','optim','io','image'};
         cd('/home/travis/octave');
         for ii=1:length(installist)
             pkg prefix '/home/travis/octave'

--- a/startup.m
+++ b/startup.m
@@ -13,7 +13,7 @@ if ~moxunit_util_platform_is_octave % MATLAB
     
 else % OCTAVE
     % install octave package
-    installlist = {'struct','statistics','optim','io','image'};
+    installlist = {'struct','io','statistics','optim','image'};
     for ii=1:length(installlist)
         try
             disp(['loading ' installlist{ii}])

--- a/startup.m
+++ b/startup.m
@@ -13,7 +13,7 @@ if ~moxunit_util_platform_is_octave % MATLAB
     
 else % OCTAVE
     % install octave package
-    installlist = {'struct','optim','io','statistics','image'};
+    installlist = {'struct','statistics','optim','io','image'};
     for ii=1:length(installlist)
         try
             disp(['loading ' installlist{ii}])

--- a/startup.m
+++ b/startup.m
@@ -13,7 +13,7 @@ if ~moxunit_util_platform_is_octave % MATLAB
     
 else % OCTAVE
     % install octave package
-    installlist = {'struct','statistics','optim','io','image'};
+    installlist = {'struct','optim','io','statistics','image'};
     for ii=1:length(installlist)
         try
             disp(['loading ' installlist{ii}])


### PR DESCRIPTION
A new version the Octave optim package was recently released (https://octave.sourceforge.io/optim/NEWS.html) and it introduces the dependency on the statistics toolbox.

A few other coincidences (I forgot to begin with a bootstrapTest.m call for the last build stage, and optim was being installed before statistics in two locations) resulted in the third build stage to start failing since this recent update. 

These fixes resolves that bug, and adds a small layer of security for the future if we decided to upgrade the optim package we intend to install.